### PR TITLE
Update grad-fellowships main page content.

### DIFF
--- a/source/funding/grad-fellowships.md
+++ b/source/funding/grad-fellowships.md
@@ -3,7 +3,34 @@ title: NYU DH Graduate Student Fellowships
 layout: page
 subtitle: |
       Graduate Students across NYU to be part of a summer cohort where they will engage in project-based training and development. Selected students receive mentoring, a $5,000 stipend, and participate in a cohort to develop their skills and sharpen their ideas.
+contents_links:
+  - label: 'Past Fellows'
+    link:
+  - label: 'FAQ'
+    link:
+resources:
+  - name: Frequently Asked Questions
+    description: ''
+    link: ''
+  - name: Grant Cycle Information
+    description: ''
+    link: ''
+  - name: Information from NYU Center for the Humanities
+    description: ''
+    link: ''
 ---
+## Digital Humanities Graduate Student Fellowship
+
+The Center for the Humanities, NYU Libraries and NYU Research Technology, fund between 8 and 10 Digital Humanities Graduate Student Fellows. Students apply with their own proposed project, which might involve–for example–engaging with digital humanities methods as the basis for a dissertation chapter or article, or building a digital public humanities project or exhibit. Project work will take place during the summer, and participants will report on work completed at an annunal fall showcase event.
+
+Proposals are judged by a Faculty Committee on the merit of the project, its contribution to the applicant’s course of study, and its feasibility in the timeline proposed. We especially welcome projects that give voice or expression to underrepresented communities; that engage with the urban fabric of the cities in which NYU has campuses; and that contribute to the emerging subfield of Global Digital Humanities.
+
+FUNDING: Fellows receive a taxable stipend of $5,000 for participating in the program, and are expected to dedicate approximately 300 hours for the fellowship during the summer months. All members of the fellowship cohort are expected to participate in project development sessions during that summer as part of their total hours, and can receive individual mentorship and technical guidance as needed.
+
+ELIGIBILITY: Graduate students in the humanities from all NYU schools, including NYU Global Sites, are eligible. To qualify, they must have completed 16 credits by June 1 and maintain active matriculation at NYU through September 1 of the year they apply. Cohort sessions may be attended remotely. Faculty-led projects, including those with graduate researchers, can be supported under the Digital Humanities Seed Grants.
+
+## Fellows
+<!-- copy over year by year structure from Seed Grants-->
 
 ## Applying to the Graduate Student Summer Fellowship Program
 


### PR DESCRIPTION
I cut down the CfH application page to the pertinent description. Any other relevant info can move into the FAQs. Since the fellowship is not a grant cycle like Seed Grants, I figure the timeline of applications/announcements/funding/showcase can live on the FAQs.