### PR TITLE
init footer

### DIFF
--- a/source/_data/footer_menu.yml
+++ b/source/_data/footer_menu.yml
@@ -1,2 +1,21 @@
-# - name: Test
-#   link: /test
+columns:
+  "Contact":
+    - name: Contact Us
+      link: '#TODO'
+    - name: Email List
+      link: 'https://groups.google.com/a/nyu.edu/g/nyudh-group?pli=1'
+    - name: Slack Channel
+      link: 'https://forms.gle/kzxyJLetPz4pGGY78'
+  "NYU Partners":
+    - name: Arts & Science
+      link: 'https://cas.nyu.edu/'
+    - name: Libraries
+      link: 'https://library.nyu.edu/'
+    - name: Information Technology
+      link: 'https://www.nyu.edu/life/information-technology.html'
+    - name: Center for the Humanities
+      link: 'https://nyuhumanities.org/'
+  "Policies":
+    - name: NYU Website Accessibility Policy
+      link: 'https://www.nyu.edu/about/policies-guidelines-compliance/policies-and-guidelines/website-accessibility.html'
+copyright: '© New York University 2022'

--- a/theme/_includes/footer.html
+++ b/theme/_includes/footer.html
@@ -1,20 +1,29 @@
-{% if site.show_footer %}
+
 <footer class="footer">
-    <div class="container">
-
-        <div class="columns is-multiline">
-            {% for item in site.data.footer_menu %}
-            <div class="column has-text-centered">
-                <div>
-                    <a href="{{ item.link | relative_url }}" class="link">{{ item.name }}</a>
-                </div>
-            </div>
-            {% endfor %}
-        </div>
-
-        <div class="content is-small has-text-centered">
-
-        </div>
+  <div class="container">
+    <div class="columns">
+      {% for col in site.data.footer_menu.columns %}
+      <div class="column">
+        <p class="has-text-bold is-size-7 is-underlined">{{ col[0] }}</p>
+        <ul class="is-size-6">
+          {% for item in col[1] %}
+          <li>
+            <a href="{{ item.link | relative_url }}" class="link" {% if item.link contains 'http' %}target="_none"{% endif %}>
+              {{ item.name }}
+            </a>
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+      {% endfor %}
     </div>
+
+    <div class="is-small">
+      <p class="logo" style="vertical-align:middle;">
+        <img src="{{ 'assets/logo.png' | absolute_url }}" style="filter:invert(100%);vertical-align:middle;width:60px;">
+        <span style="vertical-align:middle;">DH</span>
+      </p>
+      <p class="is-size-7">{{ site.data.footer_menu.copyright }}</p>
+    </div>
+  </div>
 </footer>
-{% endif %}

--- a/theme/_includes/header.html
+++ b/theme/_includes/header.html
@@ -10,7 +10,7 @@
       {% if site.data.navigation %}
         {% for item in site.data.units %}
           &nbsp;&nbsp;|&nbsp;&nbsp;
-          <a href="{{ item.link }}" class="unit-item is-size-7 has-text-white">{{ item.name }}</a>
+          <a href="{{ item.link }}" {% if item.link contains 'http' %}target="_none"{% endif %} class="unit-item is-size-7 has-text-white">{{ item.name }}</a>
         {% endfor %}
       {% endif %}
     </div>


### PR DESCRIPTION
- Closes #39, pending review.  
- Changes can be made via [_data/footer_menu.yml](https://github.com/nyu-dh/nyu-dh.github.io/blob/content/footer-39/source/_data/footer_menu.yml)

@coblezc feel free to edit that file ^ on this branch or merge & edit on `main`

**Question:** What should the "contact us" label link to? `mailto:dh.help@nyu.edu` ? Or a Google form (a la DSS/WebHosting) that goes to the dh.help alias? It might be nice to have a little buffer from mailto bots